### PR TITLE
Moved wp_footer() just before closing body tag

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -17,8 +17,8 @@
 		    </section>
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
-<?php wp_footer(); ?>
 </main><!-- /#content -->
 
+<?php wp_footer(); ?>
 </body>
 </html>


### PR DESCRIPTION
It is generally advised that wp_footer() should be called just before the closing body tag.
