### PR TITLE
Fix content position for content-none template

### DIFF
--- a/content-none.php
+++ b/content-none.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<section class="no-results not-found">
+<section class="no-results not-found hentry">
 	<header class="page-header">
 		<h1 class="page-title"><?php _e( 'Nothing Found', 'casper' ); ?></h1>
 	</header><!-- .page-header -->


### PR DESCRIPTION
When there are no posts published, the no-results message is not aligned in center.
