### PR TITLE
Fix menu z-index issue

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -157,6 +157,7 @@ function casper_customizer_head() {
         	body:not(.home) #masthead{ height: auto; border: none; }
         	body:not(.home) .blog-title, body:not(.home) .blog-description { display: none; }
         	body:not(.home) .inner { padding-top: 1em; }
+        	body:not(.home) .main-navigation { position: relative; }
         <?php } ?>
 		
 		<?php if( get_theme_mod( 'casper_link_color' )) { ?> 

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -562,7 +562,8 @@ textarea {
 .main-navigation {
     clear: both;
     display: block;
-    position: relative;
+    position: absolute;
+    top: 0;
     float: right;
     color: white;
     width: 100%;


### PR DESCRIPTION
Commit 63503710a9a80c935a93ce58ba68e0e5f7e08527 introduced a new bug: menu was not working because .main-navigation was missing CSS position property.

Could commit f0defd02877b33054d44a04f170a3e1c46352bd1 be suitable fix for this?
