### PR TITLE
Fix Email link

### DIFF
--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
                         </a>
                     <?php } ?>
                     <?php if ( false != get_theme_mod( 'casper_social_mail')) { ?>
-                        <a class="icon-envelope" href="mailto:<?php echo esc_url( get_theme_mod( 'casper_social_mail') ); ?>">
+                        <a class="icon-envelope" href="<?php echo esc_url( 'mailto:' . get_theme_mod( 'casper_social_mail') ); ?>">
                             <span class="hidden"><?php _e( 'Email', 'casper' ); ?></span>
                         </a>
                     <?php } ?>


### PR DESCRIPTION
Included "mailto:" protocol in esc_url() string so that email link does not get formatted with "http://"
