### PR TITLE
Title tag theme support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -38,6 +38,15 @@ function casper_setup() {
 	 * @link http://codex.wordpress.org/Function_Reference/add_theme_support#Post_Thumbnails
 	 */
 	add_theme_support( 'post-thumbnails' );
+	
+	/*
+	 * Let WordPress manage the document title.
+	 * By adding theme support, we declare that this theme does not use a
+	 * hard-coded <title> tag in the document head, and expect WordPress to
+	 * provide it for us.
+	 */
+	add_theme_support( 'title-tag' );
+	
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(

--- a/header.php
+++ b/header.php
@@ -15,8 +15,6 @@
 <meta name="HandheldFriendly" content="True" />
 <meta name="MobileOptimized" content="320" />
 
-<title><?php wp_title( '|', true, 'right' ); ?></title>
-
 <link rel="profile" href="http://gmpg.org/xfn/11">
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 <?php wp_head(); ?>


### PR DESCRIPTION
Let WordPress manage the document title. By adding theme support, we declare that this theme does not use a hard-coded `<title>` tag in the document head, and expect WordPress to provide it for us.
this pull request fixes #103 
